### PR TITLE
Split CI and CD workflows, add PR tooling and ruleset reference

### DIFF
--- a/.cursor/commands/create-pr.md
+++ b/.cursor/commands/create-pr.md
@@ -1,0 +1,39 @@
+---
+name: create-pr
+description: Open a GitHub pull request to main with a filled body matching the repo PR template.
+---
+
+# Create pull request
+
+Open a PR against **`main`** using **GitHub CLI** (`gh`), with a body that follows **`.github/pull_request_template.md`** (same headings: **Summary**, **Changes**, **Testing**, **Notes**).
+
+## Before creating
+
+1. Confirm the user is on the correct branch (not `main` unless they explicitly want a PR from it—usually feature branch).
+2. Ensure commits are pushed: `git push -u origin HEAD` (if upstream missing or not pushed).
+3. Inspect the diff vs `main`: `git fetch origin main` (if needed), then `git log origin/main..HEAD --oneline` and/or `git diff origin/main...HEAD` so the body matches what is actually in the PR.
+
+## Body content
+
+1. Copy the **structure** from **`.github/pull_request_template.md`**.
+2. **Fill every section** with real bullets or short prose from the diff (no empty `-` placeholders).
+3. **Remove** HTML `<!-- ... -->` comments from the final body so the description is clean in GitHub.
+4. Write the completed markdown to **`.github/pr-body.local.md`** (this path is gitignored).
+
+## Create the PR
+
+Run from the repo root, with a concise imperative **title** derived from the change:
+
+```bash
+gh pr create --base main --title "YOUR_TITLE" --body-file .github/pr-body.local.md
+```
+
+Use `--draft` if the user wants a draft PR:
+
+```bash
+gh pr create --base main --draft --title "YOUR_TITLE" --body-file .github/pr-body.local.md
+```
+
+After a successful create, print the PR URL. Optionally delete **`.github/pr-body.local.md`** or leave it for the user to discard (it will not be committed if untouched besides the ignored path).
+
+If `gh` errors (auth, no commits, merge conflicts), explain and do not claim the PR was opened.

--- a/.cursor/rules/portfolio-site.mdc
+++ b/.cursor/rules/portfolio-site.mdc
@@ -22,7 +22,7 @@ alwaysApply: true
 
 ## Deploy
 
-- **Push to `main`**: `.github/workflows/deploy.yml` syncs to S3 and invalidates CloudFront. Do not hardcode secrets; they stay in repo **Actions secrets**.
+- **Push to `main`**: `.github/workflows/cd.yml` syncs to S3 and invalidates CloudFront. PRs run `.github/workflows/ci.yml`. Do not hardcode secrets; they stay in repo **Actions secrets**.
 
 ## Data and blog
 

--- a/.cursor/rules/pull-requests.mdc
+++ b/.cursor/rules/pull-requests.mdc
@@ -7,6 +7,7 @@ alwaysApply: true
 
 ## When suggesting or drafting a PR
 
+- **Cursor command**: Run **Command `create-pr`** (see `.cursor/commands/create-pr.md`) to push the branch, write **`.github/pr-body.local.md`** from the template, and run **`gh pr create --body-file ...`**.
 - **Title**: Imperative, scoped, and readable in the merge history (e.g. “Add CI workflow for main”, not “updates”).
 - **Body**: Do not send an empty description. Follow the sections in **`.github/pull_request_template.md`** (Summary, Changes, Testing, Notes). Pre-fill with concrete bullets tied to the diff; remove sections that truly do not apply and say so briefly.
 - **Links**: Reference related issues or tickets when relevant.

--- a/.cursor/rules/pull-requests.mdc
+++ b/.cursor/rules/pull-requests.mdc
@@ -1,0 +1,17 @@
+---
+description: Opening GitHub pull requests with a clear title and filled-in body using the repo template.
+alwaysApply: true
+---
+
+# Pull requests
+
+## When suggesting or drafting a PR
+
+- **Title**: Imperative, scoped, and readable in the merge history (e.g. “Add CI workflow for main”, not “updates”).
+- **Body**: Do not send an empty description. Follow the sections in **`.github/pull_request_template.md`** (Summary, Changes, Testing, Notes). Pre-fill with concrete bullets tied to the diff; remove sections that truly do not apply and say so briefly.
+- **Links**: Reference related issues or tickets when relevant.
+- **Stack**: This repo uses separate **CI** (PRs to `main`) and **CD** (push to `main`); mention if the change touches workflows, secrets, or deploy behavior.
+
+## Default reviewers (human workflow)
+
+GitHub auto-requests reviewers from **CODEOWNERS** when a PR changes owned paths. This repo lists **`@rolani`** on `*` in **`.github/CODEOWNERS`**. To use a different handle, edit that file. Turning on “Require review from Code Owners” is optional and lives in branch rules / rulesets (stricter than auto-request alone).

--- a/.cursor/skills/portfolio-workflows/SKILL.md
+++ b/.cursor/skills/portfolio-workflows/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   partials, repos.json projects, blog posts, SEO/meta, asset cache versioning, and
   S3/CloudFront deploy implications. Use when editing index.html, partials under
   assets/static/partials/, CSS/JS under assets/static/, repos.json, blog posts,
-  sitemap/robots, or .github/workflows/deploy.yml.
+  sitemap/robots, or GitHub workflow files under .github/workflows/.
 ---
 
 # Portfolio workflows
@@ -28,4 +28,4 @@ description: >-
 
 ## Deploy awareness
 
-Push to **`main`** runs **S3 sync** and **CloudFront invalidation** (`/*`). No local build step — invalidation clears paths, but **`?v=`** bumps reduce stale asset risk for hashed routes.
+Push to **`main`** runs **CD** (S3 sync + CloudFront invalidation). Pull requests targeting **`main`** run **CI** (`.github/workflows/ci.yml`). No local build step — invalidation clears paths, but **`?v=`** bumps reduce stale asset risk for hashed routes.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Default owner for everything in the repo.
+# GitHub automatically requests review from these users when a PR modifies matching paths.
+# Change @rolani if your preferred reviewer username is different.
+* @rolani

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- Why is this change needed? 1–3 sentences. -->
+
+## Changes
+
+<!-- Bullet list of what changed (high level). -->
+
+-
+-
+
+## Testing
+
+<!-- How you verified this (local steps, CI, preview URL, etc.). -->
+
+-
+-
+
+## Notes
+
+<!-- Risks, follow-ups, cache-bust / SEO / sitemap touchpoints, or “none”. -->
+
+-

--- a/.github/rulesets/main-branch.json
+++ b/.github/rulesets/main-branch.json
@@ -1,0 +1,39 @@
+{
+  "name": "Protect main: PR and CI required",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "allowed_merge_methods": ["merge", "squash", "rebase"],
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_approving_review_count": 0,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "CI / validate"
+          }
+        ]
+      }
+    },
+    {
+      "type": "non_fast_forward"
+    }
+  ]
+}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,9 +1,18 @@
-name: Deploy to S3 and Invalidate CloudFront
+# Continuous delivery — runs only after changes land on main (typically via merged PR).
+
+name: CD
 
 on:
   push:
     branches:
       - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
 
 jobs:
   deploy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+# Continuous integration — runs on pull requests targeting main.
+# CD is .github/workflows/cd.yml (push to main only).
+#
+# After this workflow has run at least once on a PR, enable a repository ruleset
+# (or classic branch protection) that requires the check: "CI / validate"
+# See: .github/rulesets/main-branch.json
+
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Validate JSON and sitemap XML
+        run: |
+          python <<'PY'
+          import json
+          from pathlib import Path
+          from xml.etree import ElementTree as ET
+
+          root = Path(".")
+          for rel in (
+              "assets/static/json/repos.json",
+              "assets/static/blog/posts/index.json",
+          ):
+              p = root / rel
+              assert p.is_file(), f"Missing {rel}"
+              json.loads(p.read_text(encoding="utf-8"))
+
+          sm = root / "assets/static/xml/sitemap.xml"
+          assert sm.is_file(), "Missing assets/static/xml/sitemap.xml"
+          ET.parse(sm)
+          print("Site data files are valid.")
+          PY

--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,9 @@ coverage.xml
 .mypy_cache/
 .dmypy.json
 
+# Local PR description for gh pr create (Cursor command: create-pr)
+.github/pr-body.local.md
+
 # VS Code
 .vscode/
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Site Deployment Status](https://github.com/rolani/rolani.github.io/actions/workflows/deploy.yml/badge.svg)](https://github.com/rolani/rolani.github.io/actions/workflows/deploy.yml)
+[![CI](https://github.com/rolani/rolani.github.io/actions/workflows/ci.yml/badge.svg)](https://github.com/rolani/rolani.github.io/actions/workflows/ci.yml)
+[![CD](https://github.com/rolani/rolani.github.io/actions/workflows/cd.yml/badge.svg)](https://github.com/rolani/rolani.github.io/actions/workflows/cd.yml)
 
 ## Overview
 
@@ -73,17 +74,16 @@ Notes:
 
 ## Deployment (CI/CD)
 
-GitHub Actions deploys the site to AWS S3 + CloudFront on each merge to `main`.
+Pull requests to `main` run **CI** (`.github/workflows/ci.yml`). Pushes to `main` run **CD** (`.github/workflows/cd.yml`), which deploys to AWS S3 + CloudFront.
 
-Required repository secrets:
+Configure **Settings → Rules → Rulesets** (or classic branch protection) on `main` so merges require a PR and a green **CI / validate** check; use `.github/rulesets/main-branch.json` with the REST API or paste as a reference when creating the ruleset. From the repo root with the [GitHub CLI](https://cli.github.com/): `gh api repos/rolani/rolani.github.io/rulesets --method POST --input .github/rulesets/main-branch.json` (run this only after **CI** has completed on at least one PR so the check name is known to GitHub).
+
+Required repository secrets for CD:
 
 - `AWS_ACCESS_KEY_ID`
 - `AWS_SECRET_ACCESS_KEY`
 
-See `.github/workflows/deploy.yml` for deployment details.
-
-
-[![Site Deployment Status](https://github.com/rolani/rolani.github.io/actions/workflows/deploy.yml/badge.svg)](https://github.com/rolani/rolani.github.io/actions/workflows/deploy.yml)
+See `.github/workflows/cd.yml` for deployment steps.
 
 ## About
 
@@ -95,9 +95,10 @@ This site is automatically deployed to AWS S3 and CloudFront using GitHub Action
 
 ### How it works
 
-- On every merge to the `main` branch, a GitHub Actions workflow runs to:
+- **CI** runs on pull requests to `main` and validates site JSON/XML.
+- **CD** runs on every push to `main` (including merged PRs) to:
 	1. Sync the site files to the S3 bucket.
-	2. Invalidate the CloudFront distribution cache to ensure updates are live.
+	2. Invalidate the CloudFront distribution cache so updates go live.
 
 ### AWS Setup
 
@@ -110,6 +111,6 @@ These credentials must have permissions for S3 sync and CloudFront invalidation.
 
 ### Workflow file
 
-See `.github/workflows/deploy.yml` for the full workflow configuration.
+See `.github/workflows/ci.yml` and `.github/workflows/cd.yml` for workflow definitions.
 
 ---


### PR DESCRIPTION
## Summary

Introduces a dedicated **CI** workflow for pull requests to `main` (JSON/sitemap validation), moves deployment to a separate **CD** workflow on pushes to `main`, and adds repo tooling for consistent PRs: template, CODEOWNERS, Cursor rule/command, and a reference **ruleset** JSON for protecting `main` (PR + required `CI / validate`).

## Changes

- Replace single `deploy.yml` with **`ci.yml`** (on `pull_request` to `main`) and **`cd.yml`** (on `push` to `main`; S3 sync + CloudFront invalidation, concurrency group).
- Add **`.github/rulesets/main-branch.json`** for optional use with the GitHub Rules API / UI.
- Add **`.github/pull_request_template.md`**, **`.github/CODEOWNERS`** (`* @rolani`), and **`.cursor/commands/create-pr.md`** with **`.cursor/rules/pull-requests.mdc`**.
- Update **README**, **`.cursor/rules/portfolio-site.mdc`**, **`.cursor/skills/portfolio-workflows/SKILL.md`**, and **`.gitignore`** for `pr-body.local.md`.

## Testing

- Ran `git push`; branch is up to date on `origin`.
- **CI** should run on this PR and execute the Python JSON/XML validation steps in `ci.yml`.

## Notes

- The ruleset file is **not** auto-applied; enable **Settings → Rules → Rulesets** (or `gh api ...` with `.github/rulesets/main-branch.json`) when ready, after **CI / validate** has appeared at least once.
