### PR TITLE
Fix LinkedIn profile badge loading and bump actions/checkout

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Validate JSON and sitemap XML
         run: |

--- a/index.html
+++ b/index.html
@@ -41,7 +41,6 @@
       type="application/ld+json"
     >{"@context":"https://schema.org","@type":"WebSite","name":"Richard Olaniyan","url":"https://www.richolaniyan.com/"}</script>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-C4NJD8J3MD"></script>
-    <script src="https://platform.linkedin.com/badges/js/profile.js" async defer type="text/javascript"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag() {
@@ -376,14 +375,14 @@
               class="badge-base LI-profile-badge"
               data-locale="en_US"
               data-size="medium"
-              data-theme="dark"
+              data-theme="light"
               data-type="VERTICAL"
               data-vanity="richard-olaniyan"
               data-version="v1"
             >
               <a
                 class="badge-base__link LI-simple-link"
-                href="https://ca.linkedin.com/in/richard-olaniyan?trk=profile-badge"
+                href="https://www.linkedin.com/in/richard-olaniyan?trk=profile-badge"
                 >Richard Olaniyan, PhD</a
               >
             </div>
@@ -391,6 +390,7 @@
         </div>
       </section>
     </main>
+    <script defer src="https://platform.linkedin.com/badges/js/profile.js"></script>
     <footer class="site-footer">
       <div class="container footer-wrap">
         <p>Richard Olaniyan © <span data-current-year></span>. All rights reserved.</p>
@@ -475,6 +475,16 @@
             localStorage.setItem("site-theme", next);
           });
         }
+
+        window.addEventListener("load", function linkedInBadgeEnsure() {
+          window.setTimeout(function () {
+            if (typeof window.LIRenderAll !== "function") return;
+            document.querySelectorAll(".LI-profile-badge[data-rendered='true']").forEach(function (el) {
+              if (!el.querySelector("iframe")) el.removeAttribute("data-rendered");
+            });
+            window.LIRenderAll();
+          }, 750);
+        });
 
         const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
         if (!reduceMotion && "IntersectionObserver" in window) {


### PR DESCRIPTION
## Summary

Loads the LinkedIn profile badge reliably by dropping the conflicting `async`/`defer` combination, moving `profile.js` to after `</main>`, switching the embed to `defer` only, and adding a deferred retry when LinkedIn leaves the badge marked rendered without an iframe. Also bumps CI/CD workflows to current `actions/checkout`.

## Changes

- **index.html:** Remove LinkedIn `profile.js` from `<head>`; load it once with `defer` immediately after `<main>` so the badge DOM exists and script ordering matches LinkedIn’s `load`-based initializer.
- **index.html:** Set badge `data-theme` to `light` for readability on dark site chrome; normalize badge fallback link from `ca.linkedin.com` to `www.linkedin.com`.
- **index.html:** On `window` `load`, after 750 ms clear `data-rendered` only when `.LI-profile-badge` has no `iframe`, then call `LIRenderAll()` again to recover from failed JSONP.
- **.github/workflows/ci.yml** and **cd.yml:** `actions/checkout@v4` → `actions/checkout@v6`.

## Testing

- Verified local `git diff` against `origin/main` for intended HTML and workflow edits.
- Not run in browser here; recommend opening Contact section locally or after deploy with DevTools Network (LinkedIn/`licdn` not blocked).

## Notes

- Ad-blockers or strict privacy extensions can still block LinkedIn badge requests; retries only help flaky widget responses, not full third-party blocking.
- After merge, confirm GitHub Actions pass with checkout v6 and spot-check LinkedIn iframe on production.
